### PR TITLE
Validation messages are causing an error

### DIFF
--- a/mytests/global/is_html_w3c_valid.js
+++ b/mytests/global/is_html_w3c_valid.js
@@ -28,9 +28,9 @@ registerTest ('Has a Valid HTML According To W3C Validator', {
                     if (errors.length) { // invalid page, use the validator messages for the errors.
 
                         errors.each(function(){
-                          var msg = $$(this).find('em').text() + ' \n '  + $$(this).find('span.msg');
+                          var msg = $$(this).find('em').text() + ' \n '  + $$(this).find('span.msg').text();
 
-                          ok (false, msg.text());
+                          ok (false, msg);
                         });
                     } else { // page is valid
 


### PR DESCRIPTION
We're trying to print the text of the concatenated message which causes an error. I've moved the .text() up into the correct line.
